### PR TITLE
修复了 issue#6 中的问题

### DIFF
--- a/src/Region.vue
+++ b/src/Region.vue
@@ -185,7 +185,7 @@
                     this.haveCity = this.listCity.length ? true : false;
 
                     this.$nextTick(()=>{
-                        if(!this.haveCity && this.area) this.changeCity();
+                        if(!this.haveCity && this.city) this.changeCity();
                         else{
                             this.initSelected(2);
                         }


### PR DESCRIPTION
修复了#6 中描述的问题
> 省/直辖市、市
> https://terryz.gitee.io/vue/#/region/demo
> 实例里面的第二个，选择北京，无法选择第二级
> 
> 但先选一个其他省比如山西，然后再选一个城市，然后再选北京，就可以选北京的区了
> 希望一进来，就能实现这个效果

判断changecCity()的时候条件是
`if(!this.haveCity && this.area) this.changeCity();`
应该改为
`if(!this.haveCity && this.city) this.changeCity();`
因为直辖市的区是显示在city这一级的
如果先选取其他省的城市再选到北京，nowCity就会由具体数值变成""，触发一次changeCity()